### PR TITLE
Support Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     ],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^3.12",
-        "illuminate/support": "^8.71|^9.0|^10.0",
+        "illuminate/support": "^8.71|^9.0|^10.0|^11.0",
         "jigarakatidus/command-line-generator": "^1.0.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.12",
         "mockery/mockery": "^1.4.2",
         "orchestra/testbench": "^7.11",
         "phpunit/phpunit": "^9.4.4"


### PR DESCRIPTION
Add support for Laravel 11

Moved `friendsofphp/php-cs-fixer` into `dev-dependencies` as this should not be installed for all users of this package