### PR TITLE
Add HTTP Request Logging as cURL Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ Outputs
 ```bash
 curl -H 'User-Agent: GuzzleHttp/7' -H 'Accept: application/json' -H 'Content-Type: application/json' -X 'POST' 'https://example.com/api/resource' -d '{"key1":"value1","key2":"value2"}'
 ```
+## Configuration
+
+### Automatic Request Logging
+
+The package includes automatic logging of HTTP requests as cURL commands. You can publish the configuration file using the following command:
+```bash
+php artisan vendor:publish --tag=http-to-curl-config
+```
+This will create a `config/http-to-curl.php` file where you can customize the logging behavior.
+
+You can also configure these options directly through environment variables:
+
+- `HTTP_TO_CURL_LOGGING`: Enable/disable logging (defaults to true)
+- `HTTP_TO_CURL_LOG_LEVEL`: Set log level (defaults to "debug")
+- `HTTP_TO_CURL_LOG_CHANNEL`: Select log channel (defaults to "stack")
+- `HTTP_TO_CURL_LOG_TRACE`: Include trace information (defaults to true)
+
 
 ## Changelog
 

--- a/config/laravel-http-to-curl.php
+++ b/config/laravel-http-to-curl.php
@@ -10,9 +10,8 @@ return [
     |
     */
     'logging' => [
-        'enabled' => env('HTTP_TO_CURL_LOGGING', true),
+        'enabled' => env('HTTP_TO_CURL_LOGGING', false),
         'log_level' => env('HTTP_TO_CURL_LOG_LEVEL', 'debug'),
         'channel' => env('HTTP_TO_CURL_LOG_CHANNEL', 'stack'),
-        'include_trace' => env('HTTP_TO_CURL_LOG_TRACE', true),
     ],
 ];

--- a/config/laravel-http-to-curl.php
+++ b/config/laravel-http-to-curl.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Log Settings
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for request logging
+    |
+    */
+    'logging' => [
+        'enabled' => env('HTTP_TO_CURL_LOGGING', true),
+        'log_level' => env('HTTP_TO_CURL_LOG_LEVEL', 'debug'),
+        'channel' => env('HTTP_TO_CURL_LOG_CHANNEL', 'stack'),
+        'include_trace' => env('HTTP_TO_CURL_LOG_TRACE', true),
+    ],
+];

--- a/src/CurlCommandLineGenerator.php
+++ b/src/CurlCommandLineGenerator.php
@@ -30,7 +30,9 @@ class CurlCommandLineGenerator
                 $data = http_build_query($request->data());
             }
 
-            $commandGenerator->addOption('d', $data);
+            if (!empty($data)) {
+                $commandGenerator->addOption('d', $data);
+            }
 
             // TODO Multipart
         }

--- a/src/HttpToCurlServiceProvider.php
+++ b/src/HttpToCurlServiceProvider.php
@@ -6,11 +6,18 @@ use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\ServiceProvider;
 use Symfony\Component\VarDumper\VarDumper;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Http\Client\Events\RequestSending;
 
 class HttpToCurlServiceProvider extends ServiceProvider
 {
     public function boot()
     {
+        $this->publishes([
+            __DIR__ . '/../config/laravel-http-to-curl.php' => config_path('http-to-curl.php'),
+        ], 'http-to-curl-config');
+
         PendingRequest::macro('ddWithCurl', function () {
             /** @var PendingRequest $this */
             $values = func_get_args();
@@ -23,5 +30,22 @@ class HttpToCurlServiceProvider extends ServiceProvider
                 exit(1);
             });
         });
+
+        if (config("http-to-curl.logging.enabled")) {
+            Event::listen(RequestSending::class, function (RequestSending $event) {
+                $request = $event->request;
+                $curlCommand = CurlCommandLineGenerator::generate($request);
+
+                Log::channel(config("http-to-curl.logging.channel"))
+                    ->log(config("http-to-curl.logging.log_level"), $curlCommand);
+            });
+        }
+    }
+
+    public function register()
+    {
+        $this->mergeConfigFrom(
+            __DIR__ . '/../config/laravel-http-to-curl.php', 'http-to-curl'
+        );
     }
 }


### PR DESCRIPTION
- Added functionality to automatically log HTTP requests as cURL commands.

- Configuration is available through environment variables for logging status, level, channel, and trace information. All settings can be published and customized.

I didn't include tests for this please let me know if you'd like me to add them.
Closes #8